### PR TITLE
Add list of resources for drake talk in 2019

### DIFF
--- a/DataFest-2019/drake-reproducible-computation-R/resources.md
+++ b/DataFest-2019/drake-reproducible-computation-R/resources.md
@@ -1,0 +1,18 @@
+## Reading material
+
+- [Slides](https://wlandau.github.io/drake-datafest-2019) ([source](https://github.com/wlandau/drake-datafest-2019))
+- [Quick reference guide](https://ropensci.github.io/drake/)
+- [Technical manual and tutorials](https://ropenscilabs.github.io/drake-manual/)
+
+## Example code
+
+- Download the presentation's example code with `drake::drake_example("gapminder")`.
+- [Gapminder example source code](https://github.com/wlandau/drake-examples/tree/master/gapminder)
+- [Code for other `drake` examples](https://github.com/wlandau/drake-examples)
+
+## Help
+
+- [File an issue.](https://github.com/ropensci/drake/issues)
+- [Contribute code.](https://github.com/ropensci/drake/pulls)
+- [Ask on Stack Overflow with the `drake-r-package` tag.](https://stackoverflow.com/tags/drake-r-package)
+- [Discuss at rOpenSci.](https://discuss.ropensci.org/)


### PR DESCRIPTION
At [DataFest 2019](https://projects.iq.harvard.edu/datafest2019), I am [scheduled to talk](https://datafest2019.sched.com/event/JOG5/reproducable-workflows-in-r-drake-package?iframe=yes&w=100%&sidebar=yes&bg=no#) about reproducible computation with the [`drake` R package](https://github.com/ropensci/drake). This PR adds a list of links to materials from [the presentation](https://wlandau.github.io/drake-datafest-2019) and about [`drake`](https://github.com/ropensci/drake) itself.